### PR TITLE
Fix #2 - Add support for Git submodule projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies._
 
 sbtPlugin := true
 
-version          := "0.1.1"
+version          := "0.1.2"
 organization     := "io.github.todokr"
 organizationName := "todokr"
 name             := "sbt-project-switcher"


### PR DESCRIPTION
This PR solves [the issue with git submodules](#2).

For the details of the issue, please check out #2.
I haven't changed its version so you probably want to do it or if you like, I can do it. It's patch so `0.1.2` I guess?


e.g.)

```sbtshell
sbt:test-project-switcher> pjs
```

```sbtshell
  hedgehog
  example
  core
  tpsCore
  tpsCli
  justFp
  sbt-test
  runner
  tpsData
  tpsWeb
  root
> test
  12/12
```

```sbtshell
> hedgehog
  1/12
> hed
```

```sbtshell
sbt:test-project-switcher> pjs
[info] Set current project to hedgehog (in build file:/Users/kevin/git/kevin/tmp-projects/test-project-switcher/submodule/scala-hedgehog/)
[info] Set current project to hedgehog (in build file:/Users/kevin/git/kevin/tmp-projects/test-project-switcher/submodule/scala-hedgehog/)
sbt:hedgehog>
```

This fix also supports multiple sub-projects in the submodule project.

***
Another example
```sbtshell
sbt:test-project-switcher> pjs
```

```sbtshell
  hedgehog
  example
  core
  tpsCore
  tpsCli
  justFp
  sbt-test
> runner
  tpsData
  tpsWeb
  root
  test
  12/12
>
```

```sbtshell
sbt:test-project-switcher> pjs
[info] Set current project to hedgehog (in build file:/Users/kevin/git/kevin/tmp-projects/test-project-switcher/submodule/scala-hedgehog/)
[info] Set current project to hedgehog-runner (in build file:/Users/kevin/git/kevin/tmp-projects/test-project-switcher/submodule/scala-hedgehog/)
sbt:hedgehog-runner>
```

